### PR TITLE
Fix block id typo on download page faq

### DIFF
--- a/download.html
+++ b/download.html
@@ -70,7 +70,7 @@ menu: download
                 <div class="x_accordion">
                     <input id="block_655" type="checkbox">
                     <dl>
-                        <dt><label for="block_656">Do I own the content I make with Xenko?</label></dt>
+                        <dt><label for="block_655">Do I own the content I make with Xenko?</label></dt>
                         <dd>
                             <p>Yes. You own all the content you make with Xenko.</p>
                         </dd>


### PR DESCRIPTION
Fixed a typo that stopped the "Do I own the content I make with Xenko?" dropdown from functioning
Fixes #8 