### PR TITLE
chore: NPM packages bumped

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,12 +15,12 @@
         "lunr": "^2.3.9",
         "markdown-it-anchor": "^9.2.0",
         "markdown-it-table-of-contents": "^0.9.0",
-        "sass": "^1.89.2"
+        "sass": "^1.90.0"
       },
       "devDependencies": {
         "@11ty/eleventy": "^3.1.2",
         "@11ty/eleventy-plugin-rss": "^2.0.4",
-        "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.1"
+        "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2"
       },
       "engines": {
         "node": ">=18"
@@ -189,9 +189,9 @@
       }
     },
     "node_modules/@11ty/eleventy-plugin-syntaxhighlight": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-syntaxhighlight/-/eleventy-plugin-syntaxhighlight-5.0.1.tgz",
-      "integrity": "sha512-xDPF3Ay38XlmWZe9ER0SLtMmNah7olUBlGORhUiCUkPh3jYGVCDTDayi4tbFI9Dxha8NwKlfBZ2FXM/s3aZzAg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-syntaxhighlight/-/eleventy-plugin-syntaxhighlight-5.0.2.tgz",
+      "integrity": "sha512-T6xVVRDJuHlrFMHbUiZkHjj5o1IlLzZW+1IL9eUsyXFU7rY2ztcYhZew/64vmceFFpQwzuSfxQOXxTJYmKkQ+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1962,9 +1962,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.89.2",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.89.2.tgz",
-      "integrity": "sha512-xCmtksBKd/jdJ9Bt9p7nPKiuqrlBMBuuGkQlkhZjjQk3Ty48lv93k5Dq6OPkKt4XwxDJ7tvlfrTa1MPA9bf+QA==",
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.90.0.tgz",
+      "integrity": "sha512-9GUyuksjw70uNpb1MTYWsH9MQHOHY6kwfnkafC24+7aOMZn9+rVMBxRbLvw756mrBFbIsFg6Xw9IkR2Fnn3k+Q==",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@11ty/eleventy": "^3.1.2",
     "@11ty/eleventy-plugin-rss": "^2.0.4",
-    "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.1"
+    "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2"
   },
   "dependencies": {
     "@11ty/eleventy-fetch": "^5.1.0",
@@ -26,6 +26,6 @@
     "lunr": "^2.3.9",
     "markdown-it-anchor": "^9.2.0",
     "markdown-it-table-of-contents": "^0.9.0",
-    "sass": "^1.89.2"
+    "sass": "^1.90.0"
   }
 }


### PR DESCRIPTION
chore: NPM packages bumped

#### PR Classification
Dependency updates for improved functionality and performance.

#### PR Summary
This pull request updates the versions of key dependencies to enhance the project. 
- `package.json` and `package-lock.json`: Updated `sass` from `1.89.2` to `1.90.0`.
- `package.json` and `package-lock.json`: Updated `@11ty/eleventy-plugin-syntaxhighlight` from `5.0.1` to `5.0.2`.
