### PR TITLE
chore: npm packages bumped

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "lunr": "^2.3.9",
         "markdown-it-anchor": "^9.2.0",
         "markdown-it-table-of-contents": "^1.1.0",
-        "sass": "^1.93.3"
+        "sass": "^1.94.1"
       },
       "devDependencies": {
         "@11ty/eleventy": "^3.1.2",
@@ -236,9 +236,9 @@
       }
     },
     "node_modules/@11ty/eleventy/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1448,10 +1448,11 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -1959,9 +1960,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.93.3",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.93.3.tgz",
-      "integrity": "sha512-elOcIZRTM76dvxNAjqYrucTSI0teAF/L2Lv0s6f6b7FOwcwIuA357bIE871580AjHJuSvLIRUosgV+lIWx6Rgg==",
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.94.1.tgz",
+      "integrity": "sha512-/YVm5FRQaRlr3oNh2LLFYne1PdPlRZGyKnHh1sLleOqLcohTR4eUUvBjBIqkl1fEXd1MGOHgzJGJh+LgTtV4KQ==",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "lunr": "^2.3.9",
     "markdown-it-anchor": "^9.2.0",
     "markdown-it-table-of-contents": "^1.1.0",
-    "sass": "^1.93.3"
+    "sass": "^1.94.1"
   }
 }


### PR DESCRIPTION
chore: npm packages bumped

#### PR Classification
Dependency updates to improve compatibility, security, and stability.

#### PR Summary
This pull request updates the `sass` and `js-yaml` dependencies to their latest versions and adjusts related metadata in `package-lock.json`.
- Updated `sass` to `^1.94.1` in `package.json` and `package-lock.json`.
- Updated `js-yaml` to `4.1.1` for `@11ty/eleventy` and `3.14.2` for the general package in `package-lock.json`.
- Adjusted `resolved` URLs, `integrity` hashes, and added the `license` field for `js-yaml` in `package-lock.json`.
