### PR TITLE
fix: Update announcement for Stride 4.3 in .NET 10

### DIFF
--- a/posts/2025-11-14-announcing-stride-4-3-in-dotnet-10.md
+++ b/posts/2025-11-14-announcing-stride-4-3-in-dotnet-10.md
@@ -95,7 +95,6 @@ Although there have been [many fixes](https://github.com/stride3d/stride/pulls?p
 
 ### Also good to know
 
-[WIP]
 We are already hard at work on a bunch of ongoing projects for version 4.4 and beyond;
 - Continuing work to allow for building games *from* other platforms
 - Converting our Windows-only GameStudio to cross-platform through Avalonia


### PR DESCRIPTION
Removed WIP placeholder and clarified ongoing projects for version 4.4.